### PR TITLE
This commit introduces a new load balancing strategy: smooth weighted…

### DIFF
--- a/helios.yaml
+++ b/helios.yaml
@@ -4,13 +4,16 @@ server:
 backends:
   - name: "server1"
     address: "http://localhost:8081"
+    weight: 5
   - name: "server2"
     address: "http://localhost:8082"
+    weight: 2
   - name: "server3"
     address: "http://localhost:8083"
+    weight: 1
 
 load_balancer:
-  strategy: "least_connections"  # Strategi load balancing (round_robin, least_connections)
+  strategy: "weighted_round_robin"  # Options: "round_robin", "least_connections", "weighted_round_robin"
   
 health_checks:
   active:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -24,6 +24,7 @@ type ServerConfig struct {
 type BackendConfig struct {
 	Name    string `yaml:"name"`
 	Address string `yaml:"address"`
+	Weight  int    `yaml:"weight,omitempty"`
 }
 
 // LoadBalancerConfig holds the load balancer configuration

--- a/internal/loadbalancer/weighted_round_robin.go
+++ b/internal/loadbalancer/weighted_round_robin.go
@@ -1,0 +1,96 @@
+package loadbalancer
+
+import (
+	"sync"
+)
+
+// WeightedRoundRobinStrategy implements a smooth weighted round-robin load balancing strategy.
+type WeightedRoundRobinStrategy struct {
+	backends []*weightedBackend
+	mutex    sync.RWMutex
+}
+
+// weightedBackend holds the backend and its current weight.
+type weightedBackend struct {
+	backend       *Backend
+	currentWeight int
+}
+
+// NewWeightedRoundRobinStrategy creates a new weighted round-robin strategy.
+func NewWeightedRoundRobinStrategy() *WeightedRoundRobinStrategy {
+	return &WeightedRoundRobinStrategy{
+		backends: make([]*weightedBackend, 0),
+	}
+}
+
+// NextBackend returns the next backend using the smooth weighted round-robin algorithm.
+func (wrr *WeightedRoundRobinStrategy) NextBackend() *Backend {
+	wrr.mutex.Lock()
+	defer wrr.mutex.Unlock()
+
+	if len(wrr.backends) == 0 {
+		return nil
+	}
+
+	// This algorithm is based on the smooth weighted round-robin balancing algorithm used in Nginx.
+	totalWeight := 0
+	var best *weightedBackend
+
+	for _, wb := range wrr.backends {
+		// Only consider healthy backends
+		if wb.backend.IsHealthy {
+			totalWeight += wb.backend.Weight
+			wb.currentWeight += wb.backend.Weight
+
+			if best == nil || wb.currentWeight > best.currentWeight {
+				best = wb
+			}
+		}
+	}
+
+	if best == nil {
+		return nil // All backends are unhealthy
+	}
+
+	best.currentWeight -= totalWeight
+	return best.backend
+}
+
+// AddBackend adds a backend to the pool.
+func (wrr *WeightedRoundRobinStrategy) AddBackend(backend *Backend) {
+	wrr.mutex.Lock()
+	defer wrr.mutex.Unlock()
+
+	weightedBackend := &weightedBackend{
+		backend:       backend,
+		currentWeight: 0, // Initial weight is 0
+	}
+	wrr.backends = append(wrr.backends, weightedBackend)
+}
+
+// RemoveBackend removes a backend from the pool.
+func (wrr *WeightedRoundRobinStrategy) RemoveBackend(backend *Backend) {
+	wrr.mutex.Lock()
+	defer wrr.mutex.Unlock()
+
+	for i, wb := range wrr.backends {
+		if wb.backend == backend {
+			// Remove the backend by swapping with the last element and truncating.
+			wrr.backends[i] = wrr.backends[len(wrr.backends)-1]
+			wrr.backends = wrr.backends[:len(wrr.backends)-1]
+			return
+		}
+	}
+}
+
+// GetBackends returns all backends in the pool.
+func (wrr *WeightedRoundRobinStrategy) GetBackends() []*Backend {
+	wrr.mutex.RLock()
+	defer wrr.mutex.RUnlock()
+
+	backends := make([]*Backend, len(wrr.backends))
+	for i, wb := range wrr.backends {
+		backends[i] = wb.backend
+	}
+	return backends
+}

--- a/internal/loadbalancer/weighted_round_robin_test.go
+++ b/internal/loadbalancer/weighted_round_robin_test.go
@@ -1,0 +1,110 @@
+package loadbalancer
+
+import (
+	"net/url"
+	"testing"
+)
+
+func TestWeightedRoundRobinStrategy(t *testing.T) {
+	strategy := NewWeightedRoundRobinStrategy()
+
+	// Mock backends
+	backendA := &Backend{Name: "A", URL: &url.URL{}, Weight: 5, IsHealthy: true}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, Weight: 2, IsHealthy: true}
+	backendC := &Backend{Name: "C", URL: &url.URL{}, Weight: 1, IsHealthy: true}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+	strategy.AddBackend(backendC)
+
+	totalWeight := backendA.Weight + backendB.Weight + backendC.Weight // 8
+	iterations := totalWeight * 100                                  // 800
+
+	counts := make(map[string]int)
+	for i := 0; i < iterations; i++ {
+		backend := strategy.NextBackend()
+		if backend != nil {
+			counts[backend.Name]++
+		}
+	}
+
+	if len(counts) != 3 {
+		t.Errorf("Expected 3 backends to be selected, but got %d", len(counts))
+	}
+
+	expectedA := (backendA.Weight * 100)
+	expectedB := (backendB.Weight * 100)
+	expectedC := (backendC.Weight * 100)
+
+	if counts["A"] != expectedA {
+		t.Errorf("Expected backend A to be selected %d times, but got %d", expectedA, counts["A"])
+	}
+	if counts["B"] != expectedB {
+		t.Errorf("Expected backend B to be selected %d times, but got %d", expectedB, counts["B"])
+	}
+	if counts["C"] != expectedC {
+		t.Errorf("Expected backend C to be selected %d times, but got %d", expectedC, counts["C"])
+	}
+}
+
+func TestWeightedRoundRobinStrategy_WithUnhealthyBackend(t *testing.T) {
+	strategy := NewWeightedRoundRobinStrategy()
+
+	backendA := &Backend{Name: "A", URL: &url.URL{}, Weight: 5, IsHealthy: true}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, Weight: 2, IsHealthy: false} // B is unhealthy
+	backendC := &Backend{Name: "C", URL: &url.URL{}, Weight: 1, IsHealthy: true}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+	strategy.AddBackend(backendC)
+
+	totalWeight := backendA.Weight + backendC.Weight // 6
+	iterations := totalWeight * 100                  // 600
+
+	counts := make(map[string]int)
+	for i := 0; i < iterations; i++ {
+		backend := strategy.NextBackend()
+		if backend != nil {
+			counts[backend.Name]++
+		}
+	}
+
+	if len(counts) != 2 {
+		t.Errorf("Expected 2 backends to be selected, but got %d", len(counts))
+	}
+
+	if _, exists := counts["B"]; exists {
+		t.Errorf("Backend B is unhealthy and should not have been selected, but was selected %d times", counts["B"])
+	}
+
+	expectedA := (backendA.Weight * 100)
+	expectedC := (backendC.Weight * 100)
+
+	if counts["A"] != expectedA {
+		t.Errorf("Expected backend A to be selected %d times, but got %d", expectedA, counts["A"])
+	}
+	if counts["C"] != expectedC {
+		t.Errorf("Expected backend C to be selected %d times, but got %d", expectedC, counts["C"])
+	}
+}
+
+func TestWeightedRoundRobinStrategy_NoBackends(t *testing.T) {
+	strategy := NewWeightedRoundRobinStrategy()
+	if strategy.NextBackend() != nil {
+		t.Error("Expected nil when no backends are available")
+	}
+}
+
+func TestWeightedRoundRobinStrategy_AllUnhealthy(t *testing.T) {
+	strategy := NewWeightedRoundRobinStrategy()
+
+	backendA := &Backend{Name: "A", URL: &url.URL{}, Weight: 5, IsHealthy: false}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, Weight: 2, IsHealthy: false}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+
+	if strategy.NextBackend() != nil {
+		t.Error("Expected nil when all backends are unhealthy")
+	}
+}


### PR DESCRIPTION
… round-robin.

It allows you to assign a `weight` to each backend server in the configuration file. Servers with a higher weight will receive proportionally more traffic.

The implementation uses the smooth weighted round-robin algorithm, inspired by Nginx, for even request distribution.

Changes include:
- Updating config structs to support a `weight` parameter.
- Implementing the `WeightedRoundRobinStrategy` in its own file.
- Integrating the new strategy into the load balancer factory.
- Adding comprehensive unit tests to validate the weighted distribution.
- Updating the example `helios.yaml` to demonstrate the new feature.