### PR TITLE
This commit introduces the IP Hash load balancing strategy and refact…

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ backends:
     weight: 1
 
 load_balancer:
-  strategy: "weighted_round_robin"  # Options: "round_robin", "least_connections", "weighted_round_robin"
+  strategy: "ip_hash"  # Options: "round_robin", "least_connections", "weighted_round_robin", "ip_hash"
   
 health_checks:
   active:
@@ -180,6 +180,7 @@ Available strategies:
 - `round_robin`: Distributes requests sequentially across all healthy backends
 - `least_connections`: Routes to the backend with the fewest active connections
 - `weighted_round_robin`: Distributes requests based on backend weights. A backend with a higher weight will receive proportionally more requests.
+- `ip_hash`: Distributes requests based on a hash of the client's IP address. This ensures that a user will consistently be routed to the same backend server.
 
 #### Health Check Configuration
 
@@ -290,9 +291,9 @@ Contributions are welcome! Here's how you can contribute:
 
 ## Roadmap
 
-- [ ] Additional load balancing strategies
+- [x] Additional load balancing strategies
   - [x] Weighted Round Robin
-  - [ ] IP Hash
+  - [x] IP Hash
 - [ ] TLS/SSL support
 - [ ] Request rate limiting
 - [ ] Circuit breaker pattern implementation

--- a/internal/loadbalancer/ip_hash.go
+++ b/internal/loadbalancer/ip_hash.go
@@ -1,0 +1,107 @@
+package loadbalancer
+
+import (
+	"hash/fnv"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+)
+
+// IPHashStrategy implements an IP hash load balancing strategy.
+type IPHashStrategy struct {
+	backends []*Backend
+	mutex    sync.RWMutex
+}
+
+// NewIPHashStrategy creates a new IP hash strategy.
+func NewIPHashStrategy() *IPHashStrategy {
+	return &IPHashStrategy{
+		backends: make([]*Backend, 0),
+	}
+}
+
+// NextBackend returns the next backend using the IP hash algorithm.
+func (iph *IPHashStrategy) NextBackend(r *http.Request) *Backend {
+	iph.mutex.RLock()
+	defer iph.mutex.RUnlock()
+
+	if len(iph.backends) == 0 {
+		return nil
+	}
+
+	// Get healthy backends
+	healthyBackends := make([]*Backend, 0)
+	for _, b := range iph.backends {
+		if b.IsHealthy {
+			healthyBackends = append(healthyBackends, b)
+		}
+	}
+
+	if len(healthyBackends) == 0 {
+		return nil
+	}
+
+	// Get the client's IP address
+	// In a real-world scenario, you might want to trust X-Forwarded-For or X-Real-IP
+	// based on your infrastructure setup.
+	ipStr := r.Header.Get("X-Forwarded-For")
+	if ipStr == "" {
+		ipStr = r.Header.Get("X-Real-IP")
+	}
+	if ipStr == "" {
+		// Fallback to RemoteAddr
+		ip, _, err := net.SplitHostPort(r.RemoteAddr)
+		if err != nil {
+			// If SplitHostPort fails, it might be because there is no port.
+			ipStr = r.RemoteAddr
+		} else {
+			ipStr = ip
+		}
+	}
+
+	// If X-Forwarded-For has multiple IPs, take the first one.
+	if strings.Contains(ipStr, ",") {
+		ipStr = strings.Split(ipStr, ",")[0]
+	}
+
+	// Hash the IP address
+	hash := fnv.New32a()
+	hash.Write([]byte(ipStr))
+	hashValue := hash.Sum32()
+
+	// Select a backend
+	index := int(hashValue % uint32(len(healthyBackends)))
+	return healthyBackends[index]
+}
+
+// AddBackend adds a backend to the pool.
+func (iph *IPHashStrategy) AddBackend(backend *Backend) {
+	iph.mutex.Lock()
+	defer iph.mutex.Unlock()
+	iph.backends = append(iph.backends, backend)
+}
+
+// RemoveBackend removes a backend from the pool.
+func (iph *IPHashStrategy) RemoveBackend(backend *Backend) {
+	iph.mutex.Lock()
+	defer iph.mutex.Unlock()
+
+	for i, b := range iph.backends {
+		if b == backend {
+			iph.backends[i] = iph.backends[len(iph.backends)-1]
+			iph.backends = iph.backends[:len(iph.backends)-1]
+			return
+		}
+	}
+}
+
+// GetBackends returns all backends in the pool.
+func (iph *IPHashStrategy) GetBackends() []*Backend {
+	iph.mutex.RLock()
+	defer iph.mutex.RUnlock()
+
+	backends := make([]*Backend, len(iph.backends))
+	copy(backends, iph.backends)
+	return backends
+}

--- a/internal/loadbalancer/ip_hash_test.go
+++ b/internal/loadbalancer/ip_hash_test.go
@@ -1,0 +1,105 @@
+package loadbalancer
+
+import (
+	"net/http/httptest"
+	"net/url"
+	"testing"
+)
+
+func TestIPHashStrategy(t *testing.T) {
+	strategy := NewIPHashStrategy()
+
+	backendA := &Backend{Name: "A", URL: &url.URL{}, IsHealthy: true}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, IsHealthy: true}
+	backendC := &Backend{Name: "C", URL: &url.URL{}, IsHealthy: true}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+	strategy.AddBackend(backendC)
+
+	// Test with a specific IP
+	req1 := httptest.NewRequest("GET", "/", nil)
+	req1.RemoteAddr = "192.168.1.100:12345"
+
+	// The first backend selected for this IP
+	expectedBackend := strategy.NextBackend(req1)
+	if expectedBackend == nil {
+		t.Fatal("Expected a backend, but got nil")
+	}
+
+	// Subsequent requests from the same IP should go to the same backend
+	for i := 0; i < 10; i++ {
+		backend := strategy.NextBackend(req1)
+		if backend != expectedBackend {
+			t.Errorf("Expected backend %s for IP %s, but got %s", expectedBackend.Name, req1.RemoteAddr, backend.Name)
+		}
+	}
+
+	// Test with a different IP
+	req2 := httptest.NewRequest("GET", "/", nil)
+	req2.RemoteAddr = "192.168.1.101:54321"
+
+	expectedBackend2 := strategy.NextBackend(req2)
+	if expectedBackend2 == nil {
+		t.Fatal("Expected a backend, but got nil")
+	}
+	for i := 0; i < 10; i++ {
+		backend := strategy.NextBackend(req2)
+		if backend != expectedBackend2 {
+			t.Errorf("Expected backend %s for IP %s, but got %s", expectedBackend2.Name, req2.RemoteAddr, backend.Name)
+		}
+	}
+}
+
+func TestIPHashStrategy_XForwardedFor(t *testing.T) {
+	strategy := NewIPHashStrategy()
+
+	backendA := &Backend{Name: "A", URL: &url.URL{}, IsHealthy: true}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, IsHealthy: true}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+
+	// Create a request with an X-Forwarded-For header
+	req := httptest.NewRequest("GET", "/", nil)
+	req.Header.Set("X-Forwarded-For", "203.0.113.195")
+	req.RemoteAddr = "192.168.1.1:12345" // This should be ignored
+
+	expectedBackend := strategy.NextBackend(req)
+	if expectedBackend == nil {
+		t.Fatal("Expected a backend, but got nil")
+	}
+
+	// Subsequent requests with the same header should go to the same backend
+	for i := 0; i < 10; i++ {
+		backend := strategy.NextBackend(req)
+		if backend != expectedBackend {
+			t.Errorf("Expected backend %s for X-Forwarded-For %s, but got %s", expectedBackend.Name, req.Header.Get("X-Forwarded-For"), backend.Name)
+		}
+	}
+}
+
+func TestIPHashStrategy_NoBackends(t *testing.T) {
+	strategy := NewIPHashStrategy()
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+	if strategy.NextBackend(req) != nil {
+		t.Error("Expected nil when no backends are available")
+	}
+}
+
+func TestIPHashStrategy_AllUnhealthy(t *testing.T) {
+	strategy := NewIPHashStrategy()
+
+	backendA := &Backend{Name: "A", URL: &url.URL{}, IsHealthy: false}
+	backendB := &Backend{Name: "B", URL: &url.URL{}, IsHealthy: false}
+
+	strategy.AddBackend(backendA)
+	strategy.AddBackend(backendB)
+
+	req := httptest.NewRequest("GET", "/", nil)
+	req.RemoteAddr = "192.168.1.100:12345"
+	if strategy.NextBackend(req) != nil {
+		t.Error("Expected nil when all backends are unhealthy")
+	}
+}

--- a/internal/loadbalancer/least_connections.go
+++ b/internal/loadbalancer/least_connections.go
@@ -2,6 +2,7 @@ package loadbalancer
 
 import (
 	"math"
+	"net/http"
 	"sync"
 )
 
@@ -19,7 +20,7 @@ func NewLeastConnectionsStrategy() *LeastConnectionsStrategy {
 }
 
 // NextBackend returns the backend with the least active connections
-func (lc *LeastConnectionsStrategy) NextBackend() *Backend {
+func (lc *LeastConnectionsStrategy) NextBackend(r *http.Request) *Backend {
 	lc.mutex.RLock()
 	defer lc.mutex.RUnlock()
 

--- a/internal/loadbalancer/loadbalancer_test.go
+++ b/internal/loadbalancer/loadbalancer_test.go
@@ -44,8 +44,9 @@ func TestRoundRobinStrategy(t *testing.T) {
 	// Test that we can get multiple backends in sequence
 	// Note: We don't test the exact order because the implementation might change
 	seen := make(map[string]bool)
+	req := httptest.NewRequest("GET", "/", nil)
 	for i := 0; i < 3; i++ {
-		backend := rr.NextBackend()
+		backend := rr.NextBackend(req)
 		if backend == nil {
 			t.Errorf("Expected a backend, got nil")
 		} else {
@@ -89,7 +90,8 @@ func TestLeastConnectionsStrategy(t *testing.T) {
 	lc.AddBackend(backend3)
 
 	// Test least connections selection - should select backend2 with fewest connections
-	selected := lc.NextBackend()
+	req := httptest.NewRequest("GET", "/", nil)
+	selected := lc.NextBackend(req)
 	if selected != backend2 {
 		t.Errorf("Expected backend2 with fewest connections, got %s", selected.Name)
 	}
@@ -100,7 +102,7 @@ func TestLeastConnectionsStrategy(t *testing.T) {
 	backend3.ActiveConnections = 2
 
 	// Now backend1 should be selected
-	selected = lc.NextBackend()
+	selected = lc.NextBackend(req)
 	if selected != backend1 {
 		t.Errorf("Expected backend1 with fewest connections, got %s", selected.Name)
 	}
@@ -219,7 +221,7 @@ type testStrategy struct {
 	index    int
 }
 
-func (ts *testStrategy) NextBackend() *Backend {
+func (ts *testStrategy) NextBackend(r *http.Request) *Backend {
 	if len(ts.backends) == 0 {
 		return nil
 	}

--- a/internal/loadbalancer/round_robin.go
+++ b/internal/loadbalancer/round_robin.go
@@ -1,6 +1,7 @@
 package loadbalancer
 
 import (
+	"net/http"
 	"sync"
 	"sync/atomic"
 )
@@ -21,7 +22,7 @@ func NewRoundRobinStrategy() *RoundRobinStrategy {
 }
 
 // NextBackend returns the next backend in the rotation
-func (rr *RoundRobinStrategy) NextBackend() *Backend {
+func (rr *RoundRobinStrategy) NextBackend(r *http.Request) *Backend {
 	rr.mutex.RLock()
 	defer rr.mutex.RUnlock()
 

--- a/internal/loadbalancer/weighted_round_robin.go
+++ b/internal/loadbalancer/weighted_round_robin.go
@@ -1,6 +1,7 @@
 package loadbalancer
 
 import (
+	"net/http"
 	"sync"
 )
 
@@ -24,7 +25,7 @@ func NewWeightedRoundRobinStrategy() *WeightedRoundRobinStrategy {
 }
 
 // NextBackend returns the next backend using the smooth weighted round-robin algorithm.
-func (wrr *WeightedRoundRobinStrategy) NextBackend() *Backend {
+func (wrr *WeightedRoundRobinStrategy) NextBackend(r *http.Request) *Backend {
 	wrr.mutex.Lock()
 	defer wrr.mutex.Unlock()
 

--- a/internal/loadbalancer/weighted_round_robin_test.go
+++ b/internal/loadbalancer/weighted_round_robin_test.go
@@ -1,6 +1,7 @@
 package loadbalancer
 
 import (
+	"net/http/httptest"
 	"net/url"
 	"testing"
 )
@@ -21,8 +22,9 @@ func TestWeightedRoundRobinStrategy(t *testing.T) {
 	iterations := totalWeight * 100                                  // 800
 
 	counts := make(map[string]int)
+	req := httptest.NewRequest("GET", "/", nil)
 	for i := 0; i < iterations; i++ {
-		backend := strategy.NextBackend()
+		backend := strategy.NextBackend(req)
 		if backend != nil {
 			counts[backend.Name]++
 		}
@@ -62,8 +64,9 @@ func TestWeightedRoundRobinStrategy_WithUnhealthyBackend(t *testing.T) {
 	iterations := totalWeight * 100                  // 600
 
 	counts := make(map[string]int)
+	req := httptest.NewRequest("GET", "/", nil)
 	for i := 0; i < iterations; i++ {
-		backend := strategy.NextBackend()
+		backend := strategy.NextBackend(req)
 		if backend != nil {
 			counts[backend.Name]++
 		}
@@ -90,7 +93,8 @@ func TestWeightedRoundRobinStrategy_WithUnhealthyBackend(t *testing.T) {
 
 func TestWeightedRoundRobinStrategy_NoBackends(t *testing.T) {
 	strategy := NewWeightedRoundRobinStrategy()
-	if strategy.NextBackend() != nil {
+	req := httptest.NewRequest("GET", "/", nil)
+	if strategy.NextBackend(req) != nil {
 		t.Error("Expected nil when no backends are available")
 	}
 }
@@ -104,7 +108,8 @@ func TestWeightedRoundRobinStrategy_AllUnhealthy(t *testing.T) {
 	strategy.AddBackend(backendA)
 	strategy.AddBackend(backendB)
 
-	if strategy.NextBackend() != nil {
+	req := httptest.NewRequest("GET", "/", nil)
+	if strategy.NextBackend(req) != nil {
 		t.Error("Expected nil when all backends are unhealthy")
 	}
 }


### PR DESCRIPTION
…ors the core strategy interface to support request-based routing decisions.

The Strategy interface's NextBackend method now accepts an *http.Request, allowing strategies to inspect request properties.

All existing strategies (Round Robin, Least Connections, Weighted Round Robin) have been updated to conform to the new interface.

The new IP Hash strategy provides sticky sessions by hashing the client's IP address to consistently route them to the same backend server.

Unit tests have been updated and added to ensure all strategies function correctly.