### PR TITLE
I've added support for WebSocket proxying in Helios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Helios is a lightweight, high-performance HTTP reverse proxy and load balancer d
 ## Features
 
 - **HTTP Reverse Proxy**: Efficiently forwards HTTP requests to backend servers
+- **WebSocket Proxy**: Full support for proxying WebSocket connections.
 - **TLS/SSL Termination**: Secures traffic by terminating TLS connections.
 - **Advanced Load Balancing**: Multiple distribution strategies:
   - Round Robin - Distributes requests sequentially across all healthy backends
@@ -602,8 +603,8 @@ Contributions are welcome! Here's how you can contribute:
 - [x] Request rate limiting
 - [x] Circuit breaker pattern implementation
 - [x] Metrics and monitoring endpoints
+- [x] WebSocket support
 - [ ] Admin API for runtime configuration
-- [ ] WebSocket support
 - [ ] Plugin system for custom middleware
 
 ## License

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,7 @@ module github.com/0xReLogic/Helios
 
 go 1.20
 
-require gopkg.in/yaml.v3 v3.0.1 // indirect
+require (
+	github.com/gorilla/websocket v1.5.3 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
+github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/loadbalancer/loadbalancer.go
+++ b/internal/loadbalancer/loadbalancer.go
@@ -1,7 +1,10 @@
 package loadbalancer
 
 import (
+	"bufio"
+	"fmt"
 	"log"
+	"net"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
@@ -505,4 +508,13 @@ type responseWriter struct {
 func (rw *responseWriter) WriteHeader(statusCode int) {
 	rw.statusCode = statusCode
 	rw.ResponseWriter.WriteHeader(statusCode)
+}
+
+// Hijack implements the http.Hijacker interface to support websockets
+func (rw *responseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	h, ok := rw.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("response writer does not implement http.Hijacker")
+	}
+	return h.Hijack()
 }

--- a/internal/loadbalancer/loadbalancer_ws_test.go
+++ b/internal/loadbalancer/loadbalancer_ws_test.go
@@ -1,0 +1,99 @@
+package loadbalancer
+
+import (
+	"log"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/0xReLogic/Helios/internal/config"
+	"github.com/gorilla/websocket"
+)
+
+// Helper to set up a backend echo server for websocket tests
+func setupWebSocketTestBackend() *httptest.Server {
+	upgrader := websocket.Upgrader{}
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/ws" {
+			conn, err := upgrader.Upgrade(w, r, nil)
+			if err != nil {
+				log.Printf("ws upgrade error: %v", err)
+				return
+			}
+			defer conn.Close()
+			for {
+				mt, message, err := conn.ReadMessage()
+				if err != nil {
+					break // Client closed connection
+				}
+				if err := conn.WriteMessage(mt, message); err != nil {
+					break // Client closed connection
+				}
+			}
+		} else {
+			w.WriteHeader(http.StatusOK)
+		}
+	})
+	return httptest.NewServer(handler)
+}
+
+func TestWebSocketProxy(t *testing.T) {
+	// 1. Setup backend server
+	backendServer := setupWebSocketTestBackend()
+	defer backendServer.Close()
+
+	// 2. Setup Helios load balancer
+	cfg := &config.Config{
+		Backends: []config.BackendConfig{
+			{Name: "ws-backend", Address: backendServer.URL},
+		},
+		LoadBalancer: config.LoadBalancerConfig{
+			Strategy: "round_robin",
+		},
+		HealthChecks: config.HealthChecksConfig{
+			Active: config.ActiveHealthCheckConfig{
+				Enabled: false, // Disable active health checks for this test
+			},
+		},
+	}
+
+	lb, err := NewLoadBalancer(cfg)
+	if err != nil {
+		t.Fatalf("Failed to create load balancer: %v", err)
+	}
+
+	proxyServer := httptest.NewServer(lb)
+	defer proxyServer.Close()
+
+	// 3. Connect to the proxy via WebSocket
+	// Convert http:// to ws://
+	wsURL := "ws" + strings.TrimPrefix(proxyServer.URL, "http") + "/ws"
+
+	// Dial the websocket connection
+	conn, _, err := websocket.DefaultDialer.Dial(wsURL, nil)
+	if err != nil {
+		t.Fatalf("Failed to dial websocket: %v", err)
+	}
+	defer conn.Close()
+
+	// 4. Send a message and check for echo
+	testMessage := "Hello, WebSocket!"
+	if err := conn.WriteMessage(websocket.TextMessage, []byte(testMessage)); err != nil {
+		t.Fatalf("Failed to write message: %v", err)
+	}
+
+	// 5. Read the echoed message
+	conn.SetReadDeadline(time.Now().Add(5 * time.Second))
+	_, p, err := conn.ReadMessage()
+	if err != nil {
+		t.Fatalf("Failed to read message: %v", err)
+	}
+
+	if string(p) != testMessage {
+		t.Errorf("Expected message '%s', but got '%s'", testMessage, string(p))
+	}
+
+	log.Println("WebSocket test successful!")
+}


### PR DESCRIPTION
Here's a summary of the key changes I made:
- I implemented the `http.Hijacker` interface on the custom `responseWriter` in the load balancer. This allows the underlying TCP connection to be hijacked for the WebSocket protocol upgrade, which is a requirement for proxying WebSockets.
- I added a new dependency, `github.com/gorilla/websocket`, to facilitate WebSocket handling.
- I updated the test backend server with a `/ws` endpoint that acts as a WebSocket echo server for testing purposes.
- I created a new test file, `internal/loadbalancer/loadbalancer_ws_test.go`, to specifically test and verify the WebSocket proxy functionality.
- I also updated the `README.md` to include WebSocket support in the features list and marked it as complete on the project roadmap.

All existing and new tests are passing, which confirms that this feature is implemented correctly and does not introduce any regressions.