### PR TITLE
fix: Correct go.mod and go.sum for websocket dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,6 @@ module github.com/0xReLogic/Helios
 go 1.20
 
 require (
-	github.com/gorilla/websocket v1.5.3 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
+	github.com/gorilla/websocket v1.5.3
+	gopkg.in/yaml.v3 v3.0.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,6 @@
 github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aNNg=
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=


### PR DESCRIPTION
This commit fixes the build failure that occurred in the CI workflow.

The failure was caused by an inconsistent `go.mod` file where the new `github.com/gorilla/websocket` dependency was marked as indirect.

Running `go mod tidy` has corrected the `go.mod` file to mark the dependency as direct and updated the `go.sum` file with the necessary checksums. This ensures that the build process can correctly fetch and use the new dependency.